### PR TITLE
Remove deprecated allowEmptyValue property

### DIFF
--- a/contracts/documentation.yaml
+++ b/contracts/documentation.yaml
@@ -115,7 +115,6 @@ paths:
           required: false
           schema:
             type: string
-          allowEmptyValue: true
           example: laptops
         - name: q
           description: Search term.
@@ -123,7 +122,6 @@ paths:
           required: false
           schema:
             type: string
-          allowEmptyValue: true
           example: samsung
       responses:
         '200':


### PR DESCRIPTION
Per OAS 3.0.2: Use allowEmptyValue is NOT RECOMMENDED, as it is likely to be removed in a later revision